### PR TITLE
Fixed UnixSystem validatePath

### DIFF
--- a/src/System/UnixSystem.php
+++ b/src/System/UnixSystem.php
@@ -77,7 +77,7 @@ abstract class UnixSystem extends System
     {
         $absPath = $this->getAbsolutePath($path);
         $absPathParts = preg_split('/\//', preg_replace('/(^\/|\/$)/', '', $absPath));
-        $nSteps = count($absPath);
+        $nSteps = count($absPathParts);
 
         $tmpPath = '';
         $prevReadable = false;


### PR DESCRIPTION
Changed UnixSystem validatePath method to loop through path parts array instead of path string